### PR TITLE
[BUGFIX] rename `act` into `action` in Policy class

### DIFF
--- a/deer/agent.py
+++ b/deer/agent.py
@@ -325,11 +325,11 @@ class NeuralAgent(object):
         
         if self._mode != -1:
             # Act according to the test policy if not in training mode
-            action, V = self._test_policy.act(self._state)
+            action, V = self._test_policy.action(self._state)
         else:
             if self._dataset.n_elems > self._replay_start_size:
                 # follow the train policy
-                action, V = self._train_policy.act(self._state)     #is self._state the only way to store/pass the state?
+                action, V = self._train_policy.action(self._state)     #is self._state the only way to store/pass the state?
             else:
                 # Still gathering initial data: choose dummy action
                 action = self._random_state.randint(0, self._environment.nActions())

--- a/deer/base_classes/Policy.py
+++ b/deer/base_classes/Policy.py
@@ -10,13 +10,13 @@ class Policy(object):
         pass
 
     def bestAction(self, state):
-        """ Returns the best Action
+        """ Returns the best Action of the current state. This is an additional encapsulation for q-network.
         """
         action = self.q_network.chooseBestAction(state)
         V = max(self.q_network.qValues(state))
         return action, V
 
-    def act(self, state):
+    def action(self, state):
         """Main method of the Policy class. It can be called by agent.py, given a state,
         and should return a valid action w.r.t. the environment given to the constructor.
         """

--- a/deer/policies/EpsilonGreedyPolicy.py
+++ b/deer/policies/EpsilonGreedyPolicy.py
@@ -9,7 +9,7 @@ class EpsilonGreedyPolicy(Policy):
         Policy.__init__(self, q_network, n_actions, random_state)
         self._epsilon = epsilon
 
-    def act(self, state):
+    def action(self, state):
         if self.random_state.rand() < self._epsilon:
             action = self.random_state.randint(0, self.n_actions)
             V = 0


### PR DESCRIPTION
prevent the name confusion from the method `act` in Environment class