### PR TITLE
Small change of type to allow for multi dimensional actions with DDPG

### DIFF
--- a/deer/learning_algos/AC_net_keras.py
+++ b/deer/learning_algos/AC_net_keras.py
@@ -138,7 +138,8 @@ class MyACNetwork(ACNetwork):
         states_val : numpy array of objects
             Each object is a numpy array that relates to one of the observations
             with size [batch_size * history size * size of punctual observation (which is 2D,1D or scalar)]).
-        actions_val : numpy array of integers with size [self._batch_size]
+        actions_val : numpy array of objects with size [self._batch_size].
+            Each object is a numpy array of floats with size [len(self._nActions)]
             actions[i] is the action taken after having observed states[:][i].
         rewards_val : numpy array of floats with size [self._batch_size]
             rewards[i] is the reward obtained for taking actions[i-1].

--- a/deer/learning_algos/AC_net_keras.py
+++ b/deer/learning_algos/AC_net_keras.py
@@ -170,7 +170,7 @@ class MyACNetwork(ACNetwork):
         target = rewards_val + not_terminals * self._df * next_q_vals.reshape((-1))
         
         s_list=states_val.tolist()
-        s_list.append( actions_val  )
+        s_list.append( np.array(actions_val.tolist())  )
         
         # In order to obtain the individual losses, we predict the current Q_vals and calculate the diff
         q_vals=self.q_vals.predict( s_list ).reshape((-1))


### PR DESCRIPTION
_actions\_val_ is a numpy array of objects where each object is a numpy array containing the action taken at a certain step of training with a float corresponding to each dimension of the action space. The shape of _actions\_val_ is thus (_batch_size_, ). For multidimensional action spaces, this triggers an error inside Keras as the training algorithm expects an array of shape (_batch_size_, _n_dim_) where _n_dim_ is the dimensionality of the action space.

To fix this, we can transform _actions_val_ to a list, and transform that list to a numpy array. Numpy will automatically detect that each element of the list is a numpy array of _n_dim_ floats, and will therefore create an array of shape (_batch_size_, _n_dim_).