### PR TITLE
Update NN_keras.py

### DIFF
--- a/deer/learning_algos/NN_keras.py
+++ b/deer/learning_algos/NN_keras.py
@@ -63,7 +63,7 @@ class NN():
                     inputs.append(input)
                     reshaped=Reshape((dim[0],dim[1],1), input_shape=(dim[0],dim[1]))(input) 
                     x = Conv2D(16, (2, 1), activation='relu', padding='valid')(reshaped)#Conv on the history
-                    x = Conv2D(16, (2, 2), activation='relu', padding='valid')(x)       #Conv on the history & features
+                    x = Conv2D(16, (2, 1), activation='relu', padding='valid')(x)       #Conv on the history & features
 
                     out = Flatten()(x)
                 else:


### PR DESCRIPTION
In the function inputDimensions(self) in the Environment class, we fix a bug when the shape of a scalar is explicitly given.
For example, returning [(5,1)] was not allowed because [(5,)] is expected. This is fixed, which allows to return [(5,1)] or [(5,)].
Therefore, returning [(5, n)] will work for n == 1 and for n> 1.