### PR TITLE
mode dependent controllers

### DIFF
--- a/deer/agent.py
+++ b/deer/agent.py
@@ -246,7 +246,31 @@ class NeuralAgent(object):
 
         self._learning_algo.setAllParams(all_params)
 
+        
     def run(self, n_epochs, epoch_length):
+        """
+        This function encapsulates the inference and the learning.
+        If the agent is in train mode (mode = -1):
+            It starts by calling the controllers method "onStart", 
+            Then it runs a given number of epochs where an epoch is made up of one or many episodes (called with 
+            agent._runEpisode) and where an epoch ends up after the number of steps reaches the argument "epoch_length".
+            It ends up by calling the controllers method "end".
+        If the agent is on non train mode (mode > -1):
+            This function runs a number of epochs in non train mode (mode > -1), thus without controllers.
+
+        Parameters
+        -----------
+        n_epochs : int
+            number of epochs
+        epoch_length : int
+            maximum number of steps for a given epoch
+        """
+        if(self._mode==-1):
+            self._run_train(n_epochs, epoch_length)
+        else:
+            self._run_non_train(n_epochs, epoch_length)
+            
+    def _run_train(self, n_epochs, epoch_length):
         """
         This function encapsulates the whole process of the learning.
         It starts by calling the controllers method "onStart", 
@@ -274,7 +298,7 @@ class NeuralAgent(object):
         self._environment.end()
         for c in self._controllers: c.onEnd(self)
 
-    def run_non_train(self, n_epochs, epoch_length):
+    def _run_non_train(self, n_epochs, epoch_length):
         """
         This function runs a number of epochs in non train mode (id > -1), thus without controllers.
 

--- a/deer/agent.py
+++ b/deer/agent.py
@@ -289,7 +289,6 @@ class NeuralAgent(object):
         i = 0
         while i < n_epochs:
             self._training_loss_averages = []
-
             while epoch_length > 0: # run new episodes until the number of steps left for the epoch has reached 0
                 epoch_length = self._runEpisode(epoch_length)
             i += 1
@@ -300,7 +299,7 @@ class NeuralAgent(object):
 
     def _run_non_train(self, n_epochs, epoch_length):
         """
-        This function runs a number of epochs in non train mode (id > -1), thus without controllers.
+        This function runs a number of epochs in non train mode (id > -1).
 
         Parameters
         -----------
@@ -309,6 +308,7 @@ class NeuralAgent(object):
         epoch_length : int
             maximum number of steps for a given epoch
         """
+        for c in self._controllers: c.onStart(self)
         i = 0
         while i < n_epochs:
             self._totalModeNbrEpisode=0
@@ -316,6 +316,10 @@ class NeuralAgent(object):
                 self._totalModeNbrEpisode += 1
                 epoch_length = self._runEpisode(epoch_length)
             i += 1
+            for c in self._controllers: c.onEpochEnd(self)
+        
+        self._environment.end()
+        for c in self._controllers: c.onEnd(self)
 
     def _runEpisode(self, maxSteps):
         """

--- a/deer/experiment/base_controllers.py
+++ b/deer/experiment/base_controllers.py
@@ -334,7 +334,7 @@ class InterleavedTestEpochController(Controller):
         self._epoch_count += 1
         if mod == 0:
             agent.startMode(self._id, self._epoch_length)
-            agent.run_non_train(n_epochs=1, epoch_length=self._epoch_length)
+            agent._run_non_train(n_epochs=1, epoch_length=self._epoch_length)
             self._summary_counter += 1
 
             if self._show_score:


### PR DESCRIPTION
Changes in agent.py:
- Call controllers in non-train mode (agent._mode != -1).

Changes in base_controllers.py
- Add an attribute self._modes to the controllers (default is [-1]) which indicates in which mode the controller can be used.
- The controllers already implemented are adapted accordingly